### PR TITLE
Add documentation defending TIL as a legitimate programming language

### DIFF
--- a/docs/WHY_TIL_IS_A_REAL_LANGUAGE.md
+++ b/docs/WHY_TIL_IS_A_REAL_LANGUAGE.md
@@ -1,0 +1,112 @@
+# Why TIL Is a Real Programming Language
+
+## Addressing the "It's Just a Python Wrapper" Criticism
+
+---
+
+A common criticism of TIL goes something like this:
+
+> *"Why call it a new language when it's just a Python wrapper? Your compiler runs in Python every time. If it were bootstrapped or written in C, then it would truly be a separate language."*
+
+This reflects a misunderstanding of what defines a programming language versus what defines a compiler. Let's address each point.
+
+---
+
+## 1. A Language Is Defined by Its Specification, Not Its Compiler
+
+TIL is a language because it has:
+
+- **Its own grammar** — indentation-based blocks, `#[level: N]` attributes, `..` / `..=` range operators, `match`/`=>` pattern matching, `impl` blocks, `let`/`var`/`const` variable bindings
+- **Its own type system** — `int`, `float`, `bool`, `str`, `char`, sized integers (`i8`–`i64`, `u8`–`u64`), arrays, pointers, structs, enums, generics, `Option`, `Result`
+- **Its own semantics** — the multi-level system (Level 0–3), mutability rules, scope rules, value semantics for structs
+- **Its own AST** — ~30 unique node types representing TIL-specific constructs
+
+A "Python wrapper" would mean exposing Python functionality with different syntax. TIL does not execute Python code. It generates C code with its own runtime conventions (`til_` prefixed functions, `TIL_String`/`TIL_Array` types, level-based inlining attributes).
+
+The implementation language of a compiler does not determine the identity of the language it compiles.
+
+---
+
+## 2. Historical Precedent: Many Languages Started This Way
+
+| Language | Original Compiler Written In | Was It "Not a Real Language"? |
+|----------|------------------------------|-------------------------------|
+| **C++** (Cfront) | C++ → C transpiler | No |
+| **Go** (gc, pre-1.5) | C (bootstrapped to Go in 2015, 6 years later) | No |
+| **Rust** (rustboot) | OCaml (bootstrapped to Rust later) | No |
+| **Haskell** (early GHC) | Lazy ML, then C backend | No |
+| **Nim** | Originally Pascal, now self-hosted | No |
+| **Scala** | Java | No |
+| **Kotlin** | Java | No |
+| **TypeScript** | JavaScript | No |
+
+Every one of these languages had a compiler written in a different language. The compiler's implementation language is an engineering decision, not a philosophical one.
+
+**Go** is the most relevant comparison. From 2009 to 2015, the Go compiler was written in C. Nobody seriously argued that Go was "just a C wrapper" during those years. Bootstrapping came later as a maturity milestone.
+
+---
+
+## 3. Compiling to C Is a Deliberate Engineering Choice
+
+TIL compiles through C as an **intermediate representation**:
+
+```
+TIL source → Lexer → Parser → TypeChecker → C Code → GCC/Clang → Native Binary
+```
+
+This is not "double compilation" in a wasteful sense. It is a well-established technique used by:
+
+- **Nim** — compiles to C/C++/JavaScript
+- **Chicken Scheme** — compiles to C
+- **Cython** — compiles to C
+- **Vala** — compiles to C (targeting GObject/GLib)
+- **Haskell (GHC)** — historically used a C backend
+- **Felix** — compiles to C++
+
+The rationale is pragmatic: GCC and Clang represent **40+ years of optimization research**. Rather than building a custom backend with inferior optimizations, TIL leverages world-class optimizers for free. The generated C code is readable, debuggable, and benefits from platform-specific optimizations that would take years to implement independently.
+
+---
+
+## 4. What the Criticism Gets Right
+
+There is **one valid concern** embedded in this criticism: TIL's compiler requires a Python interpreter at compile time. This means:
+
+- Distributing TIL requires distributing Python (or bundling the compiler)
+- Compilation speed is limited by Python's interpreter performance
+- The toolchain has an external dependency
+
+These are real **practical limitations**, and they represent areas for future improvement:
+
+### Roadmap to Independence
+
+1. **Phase 1** (Current): Python-based compiler — fast to develop, easy to modify, proves the language design
+2. **Phase 2** (Future): Self-hosted compiler — write the TIL compiler in TIL itself, eliminating the Python dependency
+3. **Phase 3** (Future): Direct native codegen — optional LLVM or custom backend for single-pass compilation
+
+This is the same path Go, Rust, and many other languages followed. You build the language first, prove its design, then bootstrap.
+
+---
+
+## 5. The Real Question
+
+The question is not *"Is the compiler written in Python?"* — the question is:
+
+**Does TIL offer something that Python and C alone do not?**
+
+The answer is **yes**: the Multi-Level Programming System. No other language lets you write Level 0 (hardware-inlined SIMD) and Level 3 (Python-like scripting) functions in the same file, with the compiler applying different optimization and safety strategies per function. This is a genuinely novel language feature, regardless of what the compiler is implemented in.
+
+---
+
+## Summary
+
+| Claim | Reality |
+|-------|---------|
+| "It's a Python wrapper" | It has its own grammar, type system, semantics, and AST. Python is the implementation language, not the source language. |
+| "Go has its own compiler" | Go's compiler was written in C for 6 years. Bootstrapping is a maturity milestone, not a prerequisite. |
+| "Double compilation" | Compiling through C is a proven technique (Nim, Chicken Scheme, Vala, etc.) that leverages existing optimizer research. |
+| "Bootstrapping = real language" | C++ started as a C transpiler. Rust started in OCaml. TypeScript runs on JavaScript. Implementation language ≠ language identity. |
+| "Python dependency" | **Valid concern.** A self-hosted compiler is a future goal. |
+
+---
+
+*TIL is a real programming language at an early stage of its toolchain maturity. The path from "compiler written in another language" to "self-hosted compiler" is well-trodden — and TIL is on it.*


### PR DESCRIPTION
## Summary

This PR adds a comprehensive document addressing common criticisms that TIL is "just a Python wrapper" and not a real programming language. The document provides historical context, technical justification, and a roadmap for future improvements.

## Changes

- **New file**: `docs/WHY_TIL_IS_A_REAL_LANGUAGE.md`
  - Clarifies the distinction between a language's specification and its compiler implementation
  - Provides historical precedent showing that C++, Go, Rust, Haskell, Nim, Scala, Kotlin, and TypeScript all started with compilers written in other languages
  - Explains the deliberate engineering choice to compile through C as an intermediate representation, citing established precedent (Nim, Chicken Scheme, Cython, Vala, etc.)
  - Acknowledges valid practical concerns (Python dependency, compilation speed) and outlines a three-phase roadmap to a self-hosted compiler
  - Emphasizes TIL's novel contribution: the Multi-Level Programming System, which is independent of compiler implementation

## Key Points

- **Language identity** is defined by grammar, type system, semantics, and AST—not by the implementation language of the compiler
- **Compiling to C** is a pragmatic choice that leverages 40+ years of optimization research from GCC/Clang
- **Bootstrapping** is a maturity milestone, not a prerequisite for legitimacy (Go waited 6 years)
- **Valid concerns** about Python dependency are acknowledged with a clear future roadmap
- The document uses comparative analysis and historical examples to contextualize TIL's current stage of development

## Rationale

This document serves as a reference for contributors, users, and skeptics who question TIL's status as a "real" language. It preemptively addresses the most common criticism while maintaining intellectual honesty about current limitations and future goals.

https://claude.ai/code/session_01GHxUy2RHif57fTtFH58Vo5